### PR TITLE
fix argument list too long error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,4 +109,6 @@ runs:
         if [ "${{inputs.deploy}}" = "true" ]; then
           spacectl_deploy="true"
         fi
-        ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh ${{ steps.affected-stacks.outputs.affected }} $spacectl_deploy
+        printf '%s\n' "${{ steps.affected-stacks.outputs.affected }}" >affected-stacks.json
+        ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
+        rm -f affected-stacks.json

--- a/scripts/spacelift-trigger-affected-stacks.sh
+++ b/scripts/spacelift-trigger-affected-stacks.sh
@@ -12,7 +12,7 @@ success_stacks=()
 total_duration=0
 
 # Use jq to extract the spacelift_stack values and iterate through them
-for spacelift_stack in $(jq -r '.[].spacelift_stack' < "./affected-stacks.json"); do
+for spacelift_stack in $(jq -r '.[].spacelift_stack' < "./affected-stacks.json" | grep -v null); do
   start_time=$(date +%s%N)  # Get the start time in nanoseconds
 
   # Run the spacectl command, capture the error message, and store the exit status

--- a/scripts/spacelift-trigger-affected-stacks.sh
+++ b/scripts/spacelift-trigger-affected-stacks.sh
@@ -12,7 +12,7 @@ success_stacks=()
 total_duration=0
 
 # Use jq to extract the spacelift_stack values and iterate through them
-for spacelift_stack in $(jq -r '.[].spacelift_stack' < "./affected-stacks.json" | grep -v null); do
+for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
   start_time=$(date +%s%N)  # Get the start time in nanoseconds
 
   # Run the spacectl command, capture the error message, and store the exit status

--- a/scripts/spacelift-trigger-affected-stacks.sh
+++ b/scripts/spacelift-trigger-affected-stacks.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-affected_stacks=$1
 spacectl_command="preview"
 
 if [ "$2" = "true" ]; then
@@ -13,7 +12,7 @@ success_stacks=()
 total_duration=0
 
 # Use jq to extract the spacelift_stack values and iterate through them
-for spacelift_stack in $(echo "$affected_stacks" | jq -r '.[].spacelift_stack'); do
+for spacelift_stack in $(jq -r '.[].spacelift_stack' < "./affected-stacks.json"); do
   start_time=$(date +%s%N)  # Get the start time in nanoseconds
 
   # Run the spacectl command, capture the error message, and store the exit status

--- a/scripts/spacelift-trigger-affected-stacks.sh
+++ b/scripts/spacelift-trigger-affected-stacks.sh
@@ -2,7 +2,7 @@
 
 spacectl_command="preview"
 
-if [ "$2" = "true" ]; then
+if [ "$1" = "true" ]; then
   spacectl_command="deploy"
 fi
 


### PR DESCRIPTION
## what
* Fix error `scripts/spacelift-trigger-affected-stacks.sh: Argument list too long
Error: Process completed with exit code 126.` 

## why
* When the list of affected stacks is very long, it ends up being greater than the operating system `MAX_ARG_STRLEN`, which is 128KB. This fix writes the results to a file rather than passing them directly to the bash script.
