### PR TITLE
fix single quote bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,9 @@ runs:
         if [ "${{inputs.deploy}}" = "true" ]; then
           spacectl_deploy="true"
         fi
-        printf '%s\n' "${{ steps.affected-stacks.outputs.affected }}" >affected-stacks.json
+        affected="${{ steps.affected-stacks.outputs.affected }}"
+        affected="${affected#\'}"
+        affected="${affected%\'}"
+        printf "%s\n" "$affected" >affected-stacks.json
         ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
         rm -f affected-stacks.json


### PR DESCRIPTION
## what

Remove the single quotes around `${{ steps.affected-stacks.outputs.affected }}` 

## why

The file ends up with `'[...]'` which makes `jq` error out 