### PR TITLE
fix bad cloudposse/github-action-atmos-affected-stacks version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Atmos Affected Stacks
       id: affected-stacks
-      uses: cloudposse/github-action-atmos-affected-stacks@v1.0.0
+      uses: cloudposse/github-action-atmos-affected-stacks@1.0.0
       with:
         default-branch: ${{inputs.default-branch}}
         head-ref: ${{inputs.head-ref}}


### PR DESCRIPTION
## what

Fix a typo pointing to a bad version of the upstream `cloudposse/github-action-atmos-affected-stacks` module
