### PR TITLE
bump upstream cloudposse/github-action-atmos-affected-stacks@1.0.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Atmos Affected Stacks
       id: affected-stacks
-      uses: cloudposse/github-action-atmos-affected-stacks@1.0.0
+      uses: cloudposse/github-action-atmos-affected-stacks@1.0.1
       with:
         default-branch: ${{inputs.default-branch}}
         head-ref: ${{inputs.head-ref}}


### PR DESCRIPTION
## what

Bump the upstream version of cloudposse/github-action-atmos-affected-stacks to 1.0.1

## why

The upstream fixes an issue when the GitHub Runner doesn't have node installed