### PR TITLE
fix quoting issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,5 +109,5 @@ runs:
         if [ "${{inputs.deploy}}" = "true" ]; then
           spacectl_deploy="true"
         fi
-        printf "%s\n" "${{ steps.affected-stacks.outputs.affected }}" >affected-stacks.json
+        printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
         ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy


### PR DESCRIPTION
## what

Update the quoting of the `printf` command

## why

The quoting of JSON strings was being stripped with double quotes.