### PR TITLE
support using comments for triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 ## Introduction
 
 This repo contains a GitHub Action that determines the affected [Atmos](https://atmos.tools) stacks for a PR, then
-triggers the corresponding spacelift stacks.
+creates a comment on the PR which Spacelift can use to trigger the corresponding stacks via a push policy.
+
+Optionally, you can use the `spacectl` trigger method, which uses the `spacectl` CLI to trigger the corresponding
+spacelift stacks directly rather than via comment/push policy.
 
 
 
@@ -82,15 +85,24 @@ triggers the corresponding spacelift stacks.
     context:
       runs-on: ubuntu-latest
       steps:
-        - name: Atmos Affected Stacks Trigger Spacelift
+        - name: Atmos Affected Stacks Trigger Spacelift (via comment)
           uses: cloudposse/github-action-atmos-affected-trigger-spacelift@main
           id: example
           with:
             atmos-config-path: ./rootfs/usr/local/etc/atmos
             github-token: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Atmos Affected Stacks Trigger Spacelift (direct)
+          uses: cloudposse/github-action-atmos-affected-trigger-spacelift@main
+          id: example
+          with:
+            atmos-config-path: ./rootfs/usr/local/etc/atmos
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            trigger-method: spacectl
             spacelift-endpoint: https://unicorn.app.spacelift.io
             spacelift-api-key-id: ${{ secrets.SPACELIFT_API_KEY_ID }}
             spacelift-api-key-secret: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+
 ```
 
 
@@ -117,10 +129,11 @@ triggers the corresponding spacelift stacks.
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.6 | false |
 | spacectl-version | The version of spacectl to install if install-spacectl is true | latest | false |
-| spacelift-api-key-id | The SPACELIFT\_API\_KEY\_ID | N/A | true |
-| spacelift-api-key-secret | The SPACELIFT\_API\_KEY\_SECRET | N/A | true |
-| spacelift-endpoint | The Spacelift endpoint. For example, https://unicorn.app.spacelift.io | N/A | true |
+| spacelift-api-key-id | The SPACELIFT\_API\_KEY\_ID | N/A | false |
+| spacelift-api-key-secret | The SPACELIFT\_API\_KEY\_SECRET | N/A | false |
+| spacelift-endpoint | The Spacelift endpoint. For example, https://unicorn.app.spacelift.io | N/A | false |
 | terraform-version | The version of terraform to install if install-terraform is true | latest | false |
+| trigger-method | The method to use to trigger the Spacelift stack. Valid values are `comment` and `spacectl` | comment | false |
 
 
 <!-- markdownlint-restore -->

--- a/README.yaml
+++ b/README.yaml
@@ -37,7 +37,10 @@ description: GitHub Action for Triggering Affected Spacelift Stacks
 
 introduction: |-
   This repo contains a GitHub Action that determines the affected [Atmos](https://atmos.tools) stacks for a PR, then
-  triggers the corresponding spacelift stacks.
+  creates a comment on the PR which Spacelift can use to trigger the corresponding stacks via a push policy.
+
+  Optionally, you can use the `spacectl` trigger method, which uses the `spacectl` CLI to trigger the corresponding
+  spacelift stacks directly rather than via comment/push policy.
 
 references:
   - name: "github-actions-workflows"
@@ -60,15 +63,24 @@ usage: |-
       context:
         runs-on: ubuntu-latest
         steps:
-          - name: Atmos Affected Stacks Trigger Spacelift
+          - name: Atmos Affected Stacks Trigger Spacelift (via comment)
             uses: cloudposse/github-action-atmos-affected-trigger-spacelift@main
             id: example
             with:
               atmos-config-path: ./rootfs/usr/local/etc/atmos
               github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          - name: Atmos Affected Stacks Trigger Spacelift (direct)
+            uses: cloudposse/github-action-atmos-affected-trigger-spacelift@main
+            id: example
+            with:
+              atmos-config-path: ./rootfs/usr/local/etc/atmos
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              trigger-method: spacectl
               spacelift-endpoint: https://unicorn.app.spacelift.io
               spacelift-api-key-id: ${{ secrets.SPACELIFT_API_KEY_ID }}
               spacelift-api-key-secret: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+
   ```
 
 include:

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
         jq-force: ${{inputs.jq-force}}
 
     - name: Setup Spacectl
-      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}
       uses: spacelift-io/setup-spacectl@v0.3.0
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
@@ -102,7 +102,7 @@ runs:
         version: ${{inputs.spacectl-version}}
 
     - name: Trigger Spacelift Stacks with Spacectl
-      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.trigger-method == 'spacectl' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'spacectl' }}
       shell: bash
       env:
         SPACELIFT_API_KEY_ENDPOINT: ${{inputs.spacelift-endpoint}}
@@ -118,7 +118,7 @@ runs:
         ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
 
     - name: Create PR Comment Body with Affected Stacks
-      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.trigger-method == 'comment' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' }}
       id: create-pr-comment-body
       shell: bash
       run: |
@@ -132,7 +132,7 @@ runs:
 
     - name: Create PR Comment with Affected Stacks
       uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
-      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.trigger-method == 'comment' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' }}
       with:
         header: atmos-affected-stacks
         message: |

--- a/action.yml
+++ b/action.yml
@@ -137,4 +137,6 @@ runs:
         header: atmos-affected-stacks
         message: |
           ${{ steps.create-pr-comment-body.outputs.body }}
+      env:
+        GITHUB_TOKEN: ${{inputs.github-token}}
 

--- a/action.yml
+++ b/action.yml
@@ -5,68 +5,72 @@ branding:
   icon: "file"
   color: "white"
 inputs:
-  spacelift-endpoint:
-    required: true
-    description: "The Spacelift endpoint. For example, https://unicorn.app.spacelift.io"
-  spacelift-api-key-id:
-    required: true
-    description: The SPACELIFT_API_KEY_ID
-  spacelift-api-key-secret:
-    required: true
-    description: The SPACELIFT_API_KEY_SECRET
-  github-token:
-    required: true
-    description: A GitHub token for running the spacelift-io/setup-spacectl action
-  deploy:
-    default: "false"
-    description: A flag to indicate if a deployment should be triggered. If false, a preview will be triggered.
+  atmos-config-path:
+    default: .
+    description: A path to the folder where atmos.yaml is located
+    required: false
+  atmos-version:
+    default: latest
+    description: The version of atmos to install if install-atmos is true
+    required: false
   default-branch:
+    default: ${{ github.event.repository.default_branch }}
     description: The default branch to use for the base ref.
     required: false
-    default: ${{ github.event.repository.default_branch }}
+  deploy:
+    default: 'false'
+    description: A flag to indicate if a deployment should be triggered. If false, a preview will be triggered.
+  github-token:
+    description: A GitHub token for running the spacelift-io/setup-spacectl action
+    required: true
   head-ref:
     description: The head ref to checkout. If not provided, the head default branch is used.
     required: false
   install-atmos:
+    default: 'true'
     description: Whether to install atmos
     required: false
-    default: "true"
-  atmos-version:
-    description: The version of atmos to install if install-atmos is true
-    required: false
-    default: "latest"
-  atmos-config-path:
-    description: A path to the folder where atmos.yaml is located
-    required: false
-    default: .
-  install-spacectl:
-    description: Whether to install spacectl
-    required: false
-    default: "true"
-  spacectl-version:
-    description: The version of spacectl to install if install-spacectl is true
-    required: false
-    default: "latest"
-  install-terraform:
-    description: Whether to install terraform
-    required: false
-    default: "true"
-  terraform-version:
-    description: The version of terraform to install if install-terraform is true
-    required: false
-    default: "latest"
   install-jq:
+    default: 'false'
     description: Whether to install jq
     required: false
-    default: "false"
-  jq-version:
-    description: The version of jq to install if install-jq is true
+  install-spacectl:
+    default: 'true'
+    description: Whether to install spacectl
     required: false
-    default: "1.6"
+  install-terraform:
+    default: 'true'
+    description: Whether to install terraform
+    required: false
   jq-force:
+    default: 'true'
     description: Whether to force the installation of jq
     required: false
-    default: "true"
+  jq-version:
+    default: '1.6'
+    description: The version of jq to install if install-jq is true
+    required: false
+  spacectl-version:
+    default: latest
+    description: The version of spacectl to install if install-spacectl is true
+    required: false
+  spacelift-api-key-id:
+    description: The SPACELIFT_API_KEY_ID
+    required: true
+  spacelift-api-key-secret:
+    description: The SPACELIFT_API_KEY_SECRET
+    required: true
+  spacelift-endpoint:
+    description: The Spacelift endpoint. For example, https://unicorn.app.spacelift.io
+    required: true
+  terraform-version:
+    default: latest
+    description: The version of terraform to install if install-terraform is true
+    required: false
+  trigger-method:
+    default: 'comment'
+    description: The method to use to trigger the Spacelift stack. Valid values are `comment` and `spacectl`
+    required: false
 
 runs:
   using: "composite"
@@ -90,14 +94,15 @@ runs:
         jq-force: ${{inputs.jq-force}}
 
     - name: Setup Spacectl
-      if: ${{ inputs.install-spacectl == 'true' }}
+      if: ${{ inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}
       uses: spacelift-io/setup-spacectl@v0.3.0
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
       with:
         version: ${{inputs.spacectl-version}}
 
-    - name: Trigger Spacelift Stacks
+    - name: Trigger Spacelift Stacks with Spacectl
+      if: ${{ inputs.trigger-method == 'spacectl' }}
       shell: bash
       env:
         SPACELIFT_API_KEY_ENDPOINT: ${{inputs.spacelift-endpoint}}
@@ -111,3 +116,25 @@ runs:
         fi
         printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
         ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
+
+    - name: Create PR Comment Body with Affected Stacks
+      if: ${{ inputs.trigger-method == 'comment' }}
+      id: create-pr-comment-body
+      shell: bash
+      run: |
+        spacectl_deploy="false"
+        if [ "${{inputs.deploy}}" = "true" ]; then
+          spacectl_deploy="true"
+        fi
+        printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
+        body=$(${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy)
+        printf "body=%s" "$body" >>$GITHUB_OUTPUT
+
+    - name: Create PR Comment with Affected Stacks
+      uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
+      if: ${{ inputs.trigger-method == 'comment' }}
+      with:
+        header: atmos-affected-stacks
+        message: |
+          ${{ steps.create-pr-comment-body.outputs.body }}
+

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
         jq-force: ${{inputs.jq-force}}
 
     - name: Setup Spacectl
-      if: ${{ inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}
       uses: spacelift-io/setup-spacectl@v0.3.0
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
@@ -102,7 +102,7 @@ runs:
         version: ${{inputs.spacectl-version}}
 
     - name: Trigger Spacelift Stacks with Spacectl
-      if: ${{ inputs.trigger-method == 'spacectl' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.trigger-method == 'spacectl' }}
       shell: bash
       env:
         SPACELIFT_API_KEY_ENDPOINT: ${{inputs.spacelift-endpoint}}
@@ -118,7 +118,7 @@ runs:
         ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
 
     - name: Create PR Comment Body with Affected Stacks
-      if: ${{ inputs.trigger-method == 'comment' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.trigger-method == 'comment' }}
       id: create-pr-comment-body
       shell: bash
       run: |
@@ -132,7 +132,7 @@ runs:
 
     - name: Create PR Comment with Affected Stacks
       uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
-      if: ${{ inputs.trigger-method == 'comment' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stack == 'true' && inputs.trigger-method == 'comment' }}
       with:
         header: atmos-affected-stacks
         message: |

--- a/action.yml
+++ b/action.yml
@@ -56,13 +56,13 @@ inputs:
     required: false
   spacelift-api-key-id:
     description: The SPACELIFT_API_KEY_ID
-    required: true
+    required: false
   spacelift-api-key-secret:
     description: The SPACELIFT_API_KEY_SECRET
-    required: true
+    required: false
   spacelift-endpoint:
     description: The Spacelift endpoint. For example, https://unicorn.app.spacelift.io
-    required: true
+    required: false
   terraform-version:
     default: latest
     description: The version of terraform to install if install-terraform is true

--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,7 @@ runs:
       with:
         header: atmos-affected-stacks
         recreate: true
-        message-file: comment-body.txt
+        path: comment-body.txt
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
 

--- a/action.yml
+++ b/action.yml
@@ -136,8 +136,7 @@ runs:
       with:
         header: atmos-affected-stacks
         recreate: true
-        message: |
-          ${{ steps.create-pr-comment-body.outputs.body }}
+        message-file: comment-body.txt
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
 

--- a/action.yml
+++ b/action.yml
@@ -135,6 +135,7 @@ runs:
       if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' }}
       with:
         header: atmos-affected-stacks
+        recreate: true
         message: |
           ${{ steps.create-pr-comment-body.outputs.body }}
       env:

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -17,10 +17,11 @@
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.6 | false |
 | spacectl-version | The version of spacectl to install if install-spacectl is true | latest | false |
-| spacelift-api-key-id | The SPACELIFT\_API\_KEY\_ID | N/A | true |
-| spacelift-api-key-secret | The SPACELIFT\_API\_KEY\_SECRET | N/A | true |
-| spacelift-endpoint | The Spacelift endpoint. For example, https://unicorn.app.spacelift.io | N/A | true |
+| spacelift-api-key-id | The SPACELIFT\_API\_KEY\_ID | N/A | false |
+| spacelift-api-key-secret | The SPACELIFT\_API\_KEY\_SECRET | N/A | false |
+| spacelift-endpoint | The Spacelift endpoint. For example, https://unicorn.app.spacelift.io | N/A | false |
 | terraform-version | The version of terraform to install if install-terraform is true | latest | false |
+| trigger-method | The method to use to trigger the Spacelift stack. Valid values are `comment` and `spacectl` | comment | false |
 
 
 <!-- markdownlint-restore -->

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -13,4 +13,4 @@ for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | 
   body="$body\n/spacelift $spacectl_command $spacelift_stack"
 done
 
-echo -e "$body"
+echo "$body"

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -13,4 +13,4 @@ for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | 
   body="$body\n/spacelift $spacectl_command $spacelift_stack"
 done
 
-echo "$body"
+printf "%s\n" "$body"

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+spacectl_command="preview"
+
+if [ "$1" = "true" ]; then
+  spacectl_command="deploy"
+fi
+
+body=""
+
+# Use jq to extract the spacelift_stack values and iterate through them
+for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
+  body="$body\n/spacelift $spacectl_command $spacelift_stack"
+done
+
+echo -e "$body"

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -8,5 +8,5 @@ fi
 
 # Use jq to extract the spacelift_stack values and iterate through them
 for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
-  printf "/spacelift %s %s" "$spacectl_command" "$spacelift_stack" >> "comment-body.txt"
+  printf "/spacelift %s %s" "$spacectl_command" "$spacelift_stack\n" >> "comment-body.txt"
 done

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -6,11 +6,7 @@ if [ "$1" = "true" ]; then
   spacectl_command="deploy"
 fi
 
-body=""
-
 # Use jq to extract the spacelift_stack values and iterate through them
 for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
-  body="$body\n/spacelift $spacectl_command $spacelift_stack"
+  printf "/spacelift %s %s" "$spacectl_command" "$spacelift_stack" >> "comment-body.txt"
 done
-
-printf "%s\n" "$body"

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -8,5 +8,5 @@ fi
 
 # Use jq to extract the spacelift_stack values and iterate through them
 for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
-  printf "/spacelift %s %s" "$spacectl_command" "$spacelift_stack\n" >> "comment-body.txt"
+  printf "/spacelift %s %s\n" "$spacectl_command" "$spacelift_stack" >> "comment-body.txt"
 done


### PR DESCRIPTION
## what

Add the ability for GHA to trigger atmos affected stacks via comments/push policy
![CleanShot 2023-06-01 at 17 45 37](https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/assets/930247/5ff21d9d-be51-482a-a1b0-f3d6b7027e3a)


## why
* Provides a way to trigger only the atmos affected stacks while keeping the ability to still use spacelift policies to trigger runs, cancel jobs, etc.

## references
* https://docs.spacelift.io/concepts/run/pull-request-comments
* https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/push/pr-comment-driven-actions.rego
