### PR TITLE
Added major release tagger

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -13,3 +13,11 @@ jobs:
       ref: "${{ github.event.pull_request.head.ref  }}"
     secrets:
       github-private-actions-pat: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+
+  major-release-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudposse/github-action-major-release-tagger@v1
+        with:
+          log-level: 'debug'
+          dry-run: 'true'

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -13,11 +13,3 @@ jobs:
       ref: "${{ github.event.pull_request.head.ref  }}"
     secrets:
       github-private-actions-pat: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-
-  major-release-tagger:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: cloudposse/github-action-major-release-tagger@v1
-        with:
-          log-level: 'debug'
-          dry-run: 'true'

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,15 @@
+name: release-published
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudposse/github-action-major-release-tagger@v1
+        with:
+          log-level: 'debug'
+          dry-run: true

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -10,6 +10,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cloudposse/github-action-major-release-tagger@v1
-        with:
-          log-level: 'debug'
-          dry-run: true


### PR DESCRIPTION
## what
* Added major release tagger github action that will manager `v` tags.

## why
* Added major release tagger github action that will manager `v` tags.

## references
* https://github.com/cloudposse/github-action-major-release-tagger
