### PR TITLE
wrap comments in details block

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,9 +127,7 @@ runs:
           spacectl_deploy="true"
         fi
         printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
-        body=$(${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy)
-        stack_count=$(cat comment-body.txt|wc -l)
-        printf "body=<details><summary>Spacelift Triggered Stacks (%s)</summary>%s</details>" "$stack_count" "$body" >>$GITHUB_OUTPUT
+        ${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy
 
     - name: Create PR Comment with Affected Stacks
       uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2

--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,8 @@ runs:
         fi
         printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
         body=$(${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy)
-        printf "body=%s" "$body" >>$GITHUB_OUTPUT
+        stack_count=$(cat comment-body.txt|wc -l)
+        printf "body=<details><summary>Spacelift Triggered Stacks (%s)</summary>%s</details>" "$stack_count" "$body" >>$GITHUB_OUTPUT
 
     - name: Create PR Comment with Affected Stacks
       uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -15,4 +15,4 @@ done
 
 printf "</details>\n" >> "comment-body.txt"
 
-sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>" comment-body.txt
+sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n\n" comment-body.txt

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -13,6 +13,6 @@ for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | 
   stack_count=$((stack_count+1))
 done
 
+# Wrap the contents in a collapsible details block
+sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>" comment-body.txt
 printf "</details>\n" >> "comment-body.txt"
-
-sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n\n" comment-body.txt

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -7,6 +7,12 @@ if [ "$1" = "true" ]; then
 fi
 
 # Use jq to extract the spacelift_stack values and iterate through them
+stack_count=0
 for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
   printf "/spacelift %s %s\n" "$spacectl_command" "$spacelift_stack" >> "comment-body.txt"
+  stack_count=$((stack_count+1))
 done
+
+printf "</details>\n" >> "comment-body.txt"
+
+sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>" comment-body.txt


### PR DESCRIPTION
## what
* Wrap the comments in a [details](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) block

## why
* So that stacks with large numbers of affected stacks don't take up a lot of screen real estate on the PR by default

## references

Supercedes #19. Thanks to @MaxymVlasov for the contribution!
