### PR TITLE
Fix Comment Body

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,10 +128,16 @@ runs:
         fi
         printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
         ${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy
+        # Check if comment body is empty (when all affected stacks have spacelift workspace disabled)
+        if [ -s comment-body.txt ]; then
+          echo "affected-stacks-enabled=true" >> $GITHUB_OUTPUT
+        else
+          echo "affected-stacks-enabled=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: Create PR Comment with Affected Stacks
       uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
-      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' }}
+      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' && fromJSON(steps.create-pr-comment-body.outputs.affected-stacks-enabled) }}
       with:
         header: atmos-affected-stacks
         recreate: true

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -14,7 +14,7 @@ for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | 
 done
 
 # Wrap the contents in a collapsible details block
-if ["$stack_count" -gt 0]; then
+if [$stack_count -gt 0]; then
   sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n" comment-body.txt
   printf "</details>\n" >> "comment-body.txt"
 fi

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -14,7 +14,7 @@ for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | 
 done
 
 # Wrap the contents in a collapsible details block
-if [$stack_count -gt 0]; then
+if [[ $stack_count -gt 0 ]]; then
   sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n" comment-body.txt
   printf "</details>\n" >> "comment-body.txt"
 fi

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -14,5 +14,7 @@ for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | 
 done
 
 # Wrap the contents in a collapsible details block
-sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>" comment-body.txt
-printf "</details>\n" >> "comment-body.txt"
+if ["$stack_count" -gt 0]; then
+  sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>" comment-body.txt
+  printf "</details>\n" >> "comment-body.txt"
+fi

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -15,6 +15,6 @@ done
 
 # Wrap the contents in a collapsible details block
 if ["$stack_count" -gt 0]; then
-  sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>" comment-body.txt
+  sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n" comment-body.txt
   printf "</details>\n" >> "comment-body.txt"
 fi


### PR DESCRIPTION
## what
- check for empty comment before running the comment action
- correct comment body within collapsed block

## why
- If the only affected stacks have `settings.spacelift.workspace_enabled: false`, then the comment body will be empty. If the comment body is empty, then the actions fails:
```
Error: Either message or path input is required
```
- The comment body was not formatted correctly when inside a collapsed block

## references
- n/a
