### PR TITLE
fix comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,13 +144,3 @@ runs:
         path: comment-body.txt
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
-
-    - name: Hide PR Comment with Affected Stacks
-      uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
-      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' && fromJSON(steps.create-pr-comment-body.outputs.affected-stacks-enabled) }}
-      with:
-        header: atmos-affected-stacks
-        hide: true
-        hide_classify: "OUTDATED"
-      env:
-        GITHUB_TOKEN: ${{inputs.github-token}}

--- a/action.yml
+++ b/action.yml
@@ -145,3 +145,12 @@ runs:
       env:
         GITHUB_TOKEN: ${{inputs.github-token}}
 
+    - name: Hide PR Comment with Affected Stacks
+      uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
+      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' && fromJSON(steps.create-pr-comment-body.outputs.affected-stacks-enabled) }}
+      with:
+        header: atmos-affected-stacks
+        hide: true
+        hide_classify: "OUTDATED"
+      env:
+        GITHUB_TOKEN: ${{inputs.github-token}}

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -15,6 +15,6 @@ done
 
 # Wrap the contents in a collapsible details block
 if [[ $stack_count -gt 0 ]]; then
-  sed -i "1 i\<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n" comment-body.txt
+  sed -i "1 i\/spacelift summary\n\n<details><summary>Spacelift Triggered Stacks ($stack_count)</summary>\n\n" comment-body.txt
   printf "</details>\n" >> "comment-body.txt"
 fi


### PR DESCRIPTION
## what

Add `/spacelift summary` to the beginning of the comment as a hack so that spacelift will evaluate the comment

## why

Currently, spacelift will only evaluate the comment event from github if the comment begins with `/spacelift` per the documentation:

```
Please note that Spacelift will only evaluate comments that begin with/spacelift to prevent users 
from unintended actions against their resources managed by Spacelift. Furthermore, Spacelift only 
processes event data for new comments, and will not receive event data for edited or deleted comments.
```

## references
* [Spacelift Docs](https://docs.spacelift.io/concepts/run/pull-request-comments#pull-request-comment-driven-actions)
