### PR TITLE
add pattern matching fix

### DIFF
--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -9,7 +9,7 @@ fi
 # Use jq to extract the spacelift_stack values and iterate through them
 stack_count=0
 for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
-  printf "/spacelift %s %s\n" "$spacectl_command" "$spacelift_stack" >> "comment-body.txt"
+  printf "/spacelift %s %s\n" "$spacelift_stack" "$spacectl_command" >> "comment-body.txt"
   stack_count=$((stack_count+1))
 done
 


### PR DESCRIPTION
## what

Update the order of comments from `/spacelift {preview,deploy} [stackname]` to `/spacelift [stackname] {preview,deploy}`

## why

When there are stacks whose ids are substrings of other stacks, both stacks were accidentally triggered because the spacelift policy uses `contains(input.pull_request.comment, concat(" ", ["/spacelift", "preview", input.stack.id]))` to match the comments from the Pull Request.

## references

[cloudposse/terraform-spacelift-cloud-infrastructure-automation](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/pull/153) PR
