### PR TITLE
Feat/skip functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 <!-- markdownlint-disable -->
 # github-action-atmos-affected-trigger-spacelift <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content="><img align="right" src="https://cloudposse.com/logo-300x69.svg" width="150" /></a>
 <a href="https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/releases/latest"><img src="https://img.shields.io/github/release/cloudposse/github-action-atmos-affected-trigger-spacelift.svg" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/badge.svg" alt="Slack Community"/></a>
@@ -27,16 +29,6 @@
 GitHub Action for Triggering Affected Spacelift Stacks
 
 
----
-> [!NOTE]
-> This project is part of Cloud Posse's comprehensive ["SweetOps"](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=) approach towards DevOps.
-> <details><summary><strong>Learn More</strong></summary>
->
-> It's 100% Open Source and licensed under the [APACHE2](LICENSE).
->
-> </details>
-
-<a href="https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=readme_header_link"><img src="https://cloudposse.com/readme/header/img"/></a>
 
 
 ## Introduction
@@ -49,9 +41,8 @@ spacelift stacks directly rather than via comment/push policy.
 
 
 
+
 ## Usage
-
-
 
 ```yaml
   name: Pull Request
@@ -107,6 +98,7 @@ spacelift stacks directly rather than via comment/push policy.
 | install-terraform | Whether to install terraform | true | false |
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.6 | false |
+| skip-atmos-functions | Skip all Atmos functions such as terraform.output in `atmos describe affected` | false | false |
 | spacectl-version | The version of spacectl to install if install-spacectl is true | latest | false |
 | spacelift-api-key-id | The SPACELIFT\_API\_KEY\_ID | N/A | false |
 | spacelift-api-key-secret | The SPACELIFT\_API\_KEY\_SECRET | N/A | false |
@@ -132,23 +124,21 @@ For additional context, refer to some of these links.
 - [example-github-action-release-workflow](https://github.com/cloudposse/example-github-action-release-workflow) - Example application with complicated release workflow
 
 
+
+
 ## ✨ Contributing
 
 This project is under active development, and we encourage contributions from our community.
+
+
+
 Many thanks to our outstanding contributors:
 
 <a href="https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=cloudposse/github-action-atmos-affected-trigger-spacelift&max=24" />
 </a>
 
-### 🐛 Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/issues) to report any bugs or file feature requests.
-
-### 💻 Developing
-
-If you are interested in being a contributor and want to get involved in developing this project or help out with Cloud Posse's other projects, we would love to hear from you! 
-Hit us up in [Slack](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=slack), in the `#cloudposse` channel.
+For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/issues).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
  1. Review our [Code of Conduct](https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
@@ -173,38 +163,6 @@ Dropped straight into your Inbox every week — and usually a 5-minute read.
 
 [Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
 It's **FREE** for everyone!
-
-## About
-
-This project is maintained by <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=">Cloud Posse, LLC</a>.
-<a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content="><img src="https://cloudposse.com/logo-300x69.svg" align="right" /></a>
-
-We are a [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=commercial_support) for funded startups and enterprises.
-Use our ready-to-go terraform architecture blueprints for AWS to get up and running quickly.
-We build it with you. You own everything. Your team wins. Plus, we stick around until you succeed.
-
-<a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=commercial_support"><img alt="Learn More" src="https://img.shields.io/badge/learn%20more-success.svg?style=for-the-badge"/></a>
-
-*Your team can operate like a pro today.*
-
-Ensure that your team succeeds by using our proven process and turnkey blueprints. Plus, we stick around until you succeed.
-
-<details>
-  <summary>📚 <strong>See What's Included</strong></summary>
-
-- **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
-- **Deployment Strategy.** You'll have a battle-tested deployment strategy using GitHub Actions that's automated and repeatable.
-- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
-- **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
-- **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
-- **Training.** You'll receive hands-on training so your team can operate what we build.
-- **Questions.** You'll have a direct line of communication between our teams via a Shared Slack channel.
-- **Troubleshooting.** You'll get help to triage when things aren't working.
-- **Code Reviews.** You'll receive constructive feedback on Pull Requests.
-- **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
-</details>
-
-<a href="https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=readme_commercial_support_link"><img src="https://cloudposse.com/readme/commercial-support/img"/></a>
 ## License
 
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="License"></a>
@@ -239,8 +197,10 @@ under the License.
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
+
+
 ---
-Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-trigger-spacelift&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ inputs:
     default: 'comment'
     description: The method to use to trigger the Spacelift stack. Valid values are `comment` and `spacectl`
     required: false
+  skip-atmos-functions:
+    required: false
+    description: "Skip all Atmos functions such as terraform.output in `atmos describe affected`"
+    default: false
 
 runs:
   using: "composite"
@@ -80,7 +84,8 @@ runs:
 
     - name: Atmos Affected Stacks
       id: affected-stacks
-      uses: cloudposse/github-action-atmos-affected-stacks@v1
+      #uses: cloudposse/github-action-atmos-affected-stacks@v1
+      uses: cloudposse/github-action-atmos-affected-stacks@feat/skip-functions
       with:
         default-branch: ${{inputs.default-branch}}
         head-ref: ${{inputs.head-ref}}
@@ -93,6 +98,7 @@ runs:
         install-jq: ${{inputs.install-jq}}
         jq-version: ${{inputs.jq-version}}
         jq-force: ${{inputs.jq-force}}
+        skip-atmos-functions: ${{inputs.skip-atmos-functions}}
 
     - name: Setup Spacectl
       if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ inputs:
   skip-atmos-functions:
     required: false
     description: "Skip all Atmos functions such as terraform.output in `atmos describe affected`"
-    default: false
+    default: "false"
 
 runs:
   using: "composite"

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -16,6 +16,7 @@
 | install-terraform | Whether to install terraform | true | false |
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.6 | false |
+| skip-atmos-functions | Skip all Atmos functions such as terraform.output in `atmos describe affected` | false | false |
 | spacectl-version | The version of spacectl to install if install-spacectl is true | latest | false |
 | spacelift-api-key-id | The SPACELIFT\_API\_KEY\_ID | N/A | false |
 | spacelift-api-key-secret | The SPACELIFT\_API\_KEY\_SECRET | N/A | false |


### PR DESCRIPTION
## what
- Added `skip-atmos-functions` input

## why
- When `skip-atmos-functions` is true, we can skip all atmos functions. This is necessary if we do not have AWS permission in GH actions

## references
- https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/60
