### PR TITLE
Add filter-by-workspace-enabled input to skip disabled Spacelift stacks

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -55,23 +55,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - name: Verify affected stacks contain expected components
+      - name: Verify affected stacks contain test component
         run: |
           affected='${{ needs.test.outputs.affected }}'
           count=$(echo "$affected" | jq 'length')
-          if [ "$count" -ne 3 ]; then
-            echo "Expected 3 affected stacks, got $count"
+          if [ "$count" -ne 1 ]; then
+            echo "Expected 1 affected stack, got $count"
             echo "$affected" | jq .
             exit 1
           fi
-          # Verify all three components are present
-          for comp in test test-workspace-enabled test-workspace-disabled; do
-            if ! echo "$affected" | jq -e ".[] | select(.component == \"test\" and .stack_slug == \"test-t-test-${comp}\")" > /dev/null 2>&1; then
-              echo "Missing expected component: $comp"
-              exit 1
-            fi
-          done
-          echo "All 3 expected stacks found"
+          if ! echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test")' > /dev/null 2>&1; then
+            echo "Missing expected stack: test-t-test-test"
+            exit 1
+          fi
+          echo "PASS: test component correctly detected as affected"
 
       - uses: nick-fields/assert-action@v2
         with:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -55,10 +55,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
-        with:
-          expected: '[{"component":"test","component_type":"terraform","component_path":"components/terraform/test","stack":"test-t-test","stack_slug":"test-t-test-test","affected":"stack.vars","affected_all":["stack.vars"],"dependents":null,"included_in_dependents":false,"settings":null}]'
-          actual: "${{ needs.test.outputs.affected }}"
+      - name: Verify affected stacks contain expected components
+        run: |
+          affected='${{ needs.test.outputs.affected }}'
+          count=$(echo "$affected" | jq 'length')
+          if [ "$count" -ne 3 ]; then
+            echo "Expected 3 affected stacks, got $count"
+            echo "$affected" | jq .
+            exit 1
+          fi
+          # Verify all three components are present
+          for comp in test test-workspace-enabled test-workspace-disabled; do
+            if ! echo "$affected" | jq -e ".[] | select(.component == \"test\" and .stack_slug == \"test-t-test-${comp}\")" > /dev/null 2>&1; then
+              echo "Missing expected component: $comp"
+              exit 1
+            fi
+          done
+          echo "All 3 expected stacks found"
 
       - uses: nick-fields/assert-action@v2
         with:

--- a/.github/workflows/test-filter-workspace-enabled.yml
+++ b/.github/workflows/test-filter-workspace-enabled.yml
@@ -1,7 +1,16 @@
 name: Test Filter by Workspace Enabled
 on:
   pull_request: {}
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The fully-formed ref of the branch or tag that triggered the workflow run"
+        required: false
+        type: "string"
+      sha:
+        description: "The sha of the commit that triggered the workflow run"
+        required: false
+        type: "string"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/test-filter-workspace-enabled.yml
+++ b/.github/workflows/test-filter-workspace-enabled.yml
@@ -1,0 +1,84 @@
+name: Test Filter by Workspace Enabled
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: base-ref
+          fetch-depth: 0
+
+      - uses: cloudposse-github-actions/install-gh-releases@v1
+        with:
+          cache: true
+          config: |-
+            mikefarah/yq: v4.44.3
+
+      # Make a change to trigger all three test components
+      - name: Make a change
+        run: |
+          yq -i '.components.terraform.test.vars.seed = 2' ./tests/stacks/orgs/test/test.yaml
+          yq -i '.components.terraform.test-workspace-enabled.vars.seed = 2' ./tests/stacks/orgs/test/test.yaml
+          yq -i '.components.terraform.test-workspace-disabled.vars.seed = 2' ./tests/stacks/orgs/test/test.yaml
+
+      - uses: ./
+        id: current
+        with:
+          atmos-config-path: ./tests
+          atmos-include-settings: "true"
+          filter-by-workspace-enabled: "true"
+          install-atmos: true
+          skip-checkout: true
+
+    outputs:
+      affected: "${{ steps.current.outputs.affected }}"
+      has-affected-stacks: "${{ steps.current.outputs.has-affected-stacks }}"
+
+  assert:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Verify workspace_enabled=false stacks are filtered out
+        run: |
+          affected='${{ needs.test.outputs.affected }}'
+          echo "Affected stacks:"
+          echo "$affected" | jq .
+
+          # Should have affected stacks
+          if [ "${{ needs.test.outputs.has-affected-stacks }}" != "true" ]; then
+            echo "Expected has-affected-stacks to be true"
+            exit 1
+          fi
+
+          # test-workspace-disabled should NOT be in the output (workspace_enabled: false)
+          if echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test-workspace-disabled")' > /dev/null 2>&1; then
+            echo "FAIL: test-workspace-disabled should have been filtered out"
+            exit 1
+          fi
+          echo "PASS: test-workspace-disabled correctly filtered out"
+
+          # test-workspace-enabled SHOULD be in the output (workspace_enabled: true)
+          if ! echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test-workspace-enabled")' > /dev/null 2>&1; then
+            echo "FAIL: test-workspace-enabled should be present"
+            exit 1
+          fi
+          echo "PASS: test-workspace-enabled correctly included"
+
+          # test (no workspace_enabled set) SHOULD be in the output (default behavior)
+          if ! echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test")' > /dev/null 2>&1; then
+            echo "FAIL: test (no setting) should be present"
+            exit 1
+          fi
+          echo "PASS: test (no workspace_enabled) correctly included"

--- a/.github/workflows/test-filter-workspace-enabled.yml
+++ b/.github/workflows/test-filter-workspace-enabled.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 jobs:
   test:
@@ -48,6 +49,7 @@ jobs:
           atmos-config-path: ./tests
           atmos-include-settings: "true"
           filter-by-workspace-enabled: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           install-atmos: true
           skip-checkout: true
 

--- a/.github/workflows/test-filter-workspace-enabled.yml
+++ b/.github/workflows/test-filter-workspace-enabled.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - name: Verify workspace_enabled=false stacks are filtered out
+      - name: Verify affected output contains all 3 stacks
         run: |
           affected='${{ needs.test.outputs.affected }}'
           echo "Affected stacks:"
@@ -71,23 +71,42 @@ jobs:
             exit 1
           fi
 
-          # test-workspace-disabled should NOT be in the output (workspace_enabled: false)
-          if echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test-workspace-disabled")' > /dev/null 2>&1; then
+          # All 3 stacks should be in the raw affected output
+          count=$(echo "$affected" | jq 'length')
+          if [ "$count" -ne 3 ]; then
+            echo "FAIL: Expected 3 affected stacks, got $count"
+            exit 1
+          fi
+          echo "PASS: All 3 stacks detected as affected"
+
+      - name: Verify jq filter excludes workspace_enabled=false
+        run: |
+          affected='${{ needs.test.outputs.affected }}'
+
+          # Apply the same jq filter used in the scripts
+          jq_filter='.[] | select(.spacelift_stack != null) | select(.settings.spacelift.workspace_enabled != false) | .spacelift_stack'
+          filtered=$(echo "$affected" | jq -r "$jq_filter")
+          echo "Filtered spacelift stacks:"
+          echo "$filtered"
+
+          # test-workspace-enabled should be in filtered output (workspace_enabled: true, has spacelift_stack)
+          if ! echo "$filtered" | grep -q "test-t-test-test-workspace-enabled"; then
+            echo "FAIL: test-workspace-enabled should be present after filtering"
+            exit 1
+          fi
+          echo "PASS: test-workspace-enabled correctly included"
+
+          # test-workspace-disabled should NOT be in filtered output (workspace_enabled: false)
+          # It has no spacelift_stack field, so it's filtered by the first select
+          if echo "$filtered" | grep -q "test-workspace-disabled"; then
             echo "FAIL: test-workspace-disabled should have been filtered out"
             exit 1
           fi
           echo "PASS: test-workspace-disabled correctly filtered out"
 
-          # test-workspace-enabled SHOULD be in the output (workspace_enabled: true)
-          if ! echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test-workspace-enabled")' > /dev/null 2>&1; then
-            echo "FAIL: test-workspace-enabled should be present"
+          # test (no spacelift settings) should NOT be in filtered output (no spacelift_stack field)
+          if echo "$filtered" | grep -q "test-t-test-test$"; then
+            echo "FAIL: test (no spacelift_stack) should not be in spacelift trigger list"
             exit 1
           fi
-          echo "PASS: test-workspace-enabled correctly included"
-
-          # test (no workspace_enabled set) SHOULD be in the output (default behavior)
-          if ! echo "$affected" | jq -e '.[] | select(.stack_slug == "test-t-test-test")' > /dev/null 2>&1; then
-            echo "FAIL: test (no setting) should be present"
-            exit 1
-          fi
-          echo "PASS: test (no workspace_enabled) correctly included"
+          echo "PASS: test (no spacelift_stack) correctly excluded from trigger list"

--- a/action.yml
+++ b/action.yml
@@ -102,6 +102,10 @@ inputs:
   spacelift-endpoint:
     description: The Spacelift endpoint. For example, https://unicorn.app.spacelift.io
     required: false
+  filter-by-workspace-enabled:
+    default: 'false'
+    description: "Filter out stacks where settings.spacelift.workspace_enabled is false. When enabled, only stacks with workspace_enabled not explicitly set to false will be triggered or posted in PR comments."
+    required: false
   trigger-method:
     default: 'comment'
     description: The method to use to trigger the Spacelift stack. Valid values are `comment` and `spacectl`
@@ -130,7 +134,7 @@ runs:
       with:
         atmos-config-path: ${{inputs.atmos-config-path}}
         atmos-include-dependents: ${{inputs.atmos-include-dependents}}
-        atmos-include-settings: ${{inputs.atmos-include-settings}}
+        atmos-include-settings: ${{ inputs.filter-by-workspace-enabled == 'true' || inputs.atmos-include-settings == 'true' }}
         atmos-include-spacelift-admin-stacks: ${{inputs.atmos-include-spacelift-admin-stacks}}
         atmos-stack: ${{inputs.atmos-stack}}
         atmos-version: ${{inputs.atmos-version}}
@@ -170,7 +174,7 @@ runs:
           spacectl_deploy="true"
         fi
         printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
-        ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
+        FILTER_BY_WORKSPACE_ENABLED="${{inputs.filter-by-workspace-enabled}}" ${GITHUB_ACTION_PATH}/scripts/spacelift-trigger-affected-stacks.sh $spacectl_deploy
 
     - name: Create PR Comment Body with Affected Stacks
       if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.trigger-method == 'comment' }}
@@ -182,7 +186,7 @@ runs:
           spacectl_deploy="true"
         fi
         printf "%s\n" '${{ steps.affected-stacks.outputs.affected }}' >affected-stacks.json
-        ${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy
+        FILTER_BY_WORKSPACE_ENABLED="${{inputs.filter-by-workspace-enabled}}" ${GITHUB_ACTION_PATH}/scripts/spacelift-generate-pr-comment-body.sh $spacectl_deploy
         # Check if comment body is empty (when all affected stacks have spacelift workspace disabled)
         if [ -s comment-body.txt ]; then
           echo "affected-stacks-enabled=true" >> $GITHUB_OUTPUT

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -6,9 +6,16 @@ if [ "$1" = "true" ]; then
   spacectl_command="deploy"
 fi
 
+# Build jq filter based on whether workspace_enabled filtering is enabled
+jq_filter='.[] | select(.spacelift_stack != null)'
+if [ "${FILTER_BY_WORKSPACE_ENABLED}" = "true" ]; then
+  jq_filter="${jq_filter} | select((.settings.spacelift.workspace_enabled // true) != false)"
+fi
+jq_filter="${jq_filter} | .spacelift_stack"
+
 # Use jq to extract the spacelift_stack values and iterate through them
 stack_count=0
-for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
+for spacelift_stack in $(jq -r "${jq_filter}" < "affected-stacks.json"); do
   printf "/spacelift %s %s\n" "$spacelift_stack" "$spacectl_command" >> "comment-body.txt"
   stack_count=$((stack_count+1))
 done

--- a/scripts/spacelift-generate-pr-comment-body.sh
+++ b/scripts/spacelift-generate-pr-comment-body.sh
@@ -9,7 +9,7 @@ fi
 # Build jq filter based on whether workspace_enabled filtering is enabled
 jq_filter='.[] | select(.spacelift_stack != null)'
 if [ "${FILTER_BY_WORKSPACE_ENABLED}" = "true" ]; then
-  jq_filter="${jq_filter} | select((.settings.spacelift.workspace_enabled // true) != false)"
+  jq_filter="${jq_filter} | select(.settings.spacelift.workspace_enabled != false)"
 fi
 jq_filter="${jq_filter} | .spacelift_stack"
 

--- a/scripts/spacelift-trigger-affected-stacks.sh
+++ b/scripts/spacelift-trigger-affected-stacks.sh
@@ -11,8 +11,15 @@ success_stacks=()
 
 total_duration=0
 
+# Build jq filter based on whether workspace_enabled filtering is enabled
+jq_filter='.[] | select(.spacelift_stack != null)'
+if [ "${FILTER_BY_WORKSPACE_ENABLED}" = "true" ]; then
+  jq_filter="${jq_filter} | select((.settings.spacelift.workspace_enabled // true) != false)"
+fi
+jq_filter="${jq_filter} | .spacelift_stack"
+
 # Use jq to extract the spacelift_stack values and iterate through them
-for spacelift_stack in $(jq -r '.[].spacelift_stack' < "affected-stacks.json" | grep -v null); do
+for spacelift_stack in $(jq -r "${jq_filter}" < "affected-stacks.json"); do
   start_time=$(date +%s%N)  # Get the start time in nanoseconds
 
   # Run the spacectl command, capture the error message, and store the exit status

--- a/scripts/spacelift-trigger-affected-stacks.sh
+++ b/scripts/spacelift-trigger-affected-stacks.sh
@@ -14,7 +14,7 @@ total_duration=0
 # Build jq filter based on whether workspace_enabled filtering is enabled
 jq_filter='.[] | select(.spacelift_stack != null)'
 if [ "${FILTER_BY_WORKSPACE_ENABLED}" = "true" ]; then
-  jq_filter="${jq_filter} | select((.settings.spacelift.workspace_enabled // true) != false)"
+  jq_filter="${jq_filter} | select(.settings.spacelift.workspace_enabled != false)"
 fi
 jq_filter="${jq_filter} | .spacelift_stack"
 

--- a/tests/stacks/orgs/test/test.yaml
+++ b/tests/stacks/orgs/test/test.yaml
@@ -9,3 +9,19 @@ components:
     test:
       vars:
         seed: 1
+    test-workspace-enabled:
+      metadata:
+        component: test
+      settings:
+        spacelift:
+          workspace_enabled: true
+      vars:
+        seed: 1
+    test-workspace-disabled:
+      metadata:
+        component: test
+      settings:
+        spacelift:
+          workspace_enabled: false
+      vars:
+        seed: 1


### PR DESCRIPTION
## What

Add a new `filter-by-workspace-enabled` input (default `false`) that filters out affected stacks where `settings.spacelift.workspace_enabled` is explicitly `false` before posting PR comments or triggering via spacectl.

## Why

When migrating stacks from Spacelift to Atmos Pro, `workspace_enabled` is set to `false` for those stacks. However, this action still lists them in PR comments, creating confusion — stacks appear in the comment but are never triggered. This input allows consumers to opt into filtering so only Spacelift-enabled stacks are shown.

## Changes

- New input `filter-by-workspace-enabled` (default `false`) — no breaking change
- When enabled, `atmos-include-settings` is automatically set to `true` (required for the filter)
- Both `spacelift-generate-pr-comment-body.sh` and `spacelift-trigger-affected-stacks.sh` conditionally filter stacks using jq when the flag is set
- Stacks without an explicit `workspace_enabled` setting default to enabled (preserving current behavior)