### PR TITLE
fix: remove redundant atmos describe affected re-run, rely on upstream OOM fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ runs:
       with:
         atmos-config-path: ${{inputs.atmos-config-path}}
         atmos-include-dependents: ${{inputs.atmos-include-dependents}}
-        atmos-include-settings: ${{ inputs.atmos-include-settings }}
+        atmos-include-settings: ${{ inputs.filter-by-workspace-enabled == 'true' || inputs.atmos-include-settings == 'true' }}
         atmos-include-spacelift-admin-stacks: ${{inputs.atmos-include-spacelift-admin-stacks}}
         atmos-stack: ${{inputs.atmos-stack}}
         atmos-version: ${{inputs.atmos-version}}
@@ -151,20 +151,6 @@ runs:
         process-templates: ${{ inputs.skip-process-templates != 'true' }}
         skip-atmos-functions: ${{inputs.skip-atmos-functions}}
         skip-checkout: ${{inputs.skip-checkout}}
-
-    # When filtering by workspace_enabled, we need settings in the affected stacks data.
-    # We can't include settings via the upstream action because the large payload in
-    # GITHUB_OUTPUT causes GitHub Actions' expression evaluator to OOM.
-    # Instead, re-run atmos describe affected with --include-settings writing directly
-    # to file, bypassing GITHUB_OUTPUT entirely.
-    - name: Enrich affected stacks with settings for filtering
-      if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.filter-by-workspace-enabled == 'true' }}
-      shell: bash
-      run: |
-        atmos describe affected \
-          --include-settings \
-          --file affected-stacks.json \
-          --repo-path "${GITHUB_WORKSPACE}/base-ref"
 
     - name: Setup Spacectl
       if: ${{ steps.affected-stacks.outputs.has-affected-stacks == 'true' && inputs.install-spacectl == 'true' && inputs.trigger-method == 'spacectl' }}


### PR DESCRIPTION
## What
- Remove the "Enrich affected stacks with settings for filtering" step that re-ran `atmos describe affected` with `--include-settings`
- Restore `atmos-include-settings` to be automatically enabled when `filter-by-workspace-enabled` is true
- Rely on the upstream `github-action-atmos-affected-stacks` fix (cloudposse/github-action-atmos-affected-stacks#88) which caps `$GITHUB_OUTPUT` size to prevent OOM

## Why
- The "Enrich" step re-ran `atmos describe affected` a second time, doubling execution time for large repos
- It didn't respect the upstream action's input flags (skip-functions, process-templates, etc.)
- The upstream action now handles large payloads by only writing to `$GITHUB_OUTPUT` if under 1MB, and computing `has-affected-stacks` as a separate boolean output

## Ref
- Depends on cloudposse/github-action-atmos-affected-stacks#88